### PR TITLE
Fix bug where line was being wrapped after every word.

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -8,8 +8,8 @@ import Text.Wrap
 main :: IO ()
 main = hspec $ do
     it "leaves short lines untouched" $ do
-      wrapTextToLines defaultWrapSettings 5 "foo"
-        `shouldBe` ["foo"]
+      wrapTextToLines defaultWrapSettings 7 "foo bar"
+        `shouldBe` ["foo bar"]
 
     it "wraps long lines" $ do
       wrapTextToLines defaultWrapSettings 7 "Hello, World!"


### PR DESCRIPTION
`0.3.3` was wrapping after every word because the general case was never reached. This is mostly a reorder.