### PR TITLE
ensure indent width is never greater than or equal to the target width

### DIFF
--- a/src/Text/Wrap.hs
+++ b/src/Text/Wrap.hs
@@ -83,7 +83,7 @@ wrapLine settings limit t =
                 Just rest -> firstLineText : go lim rest
         (indent, modifiedText) = if preserveIndentation settings
                          then let i = T.takeWhile isSpace t
-                              in (i, T.drop (T.length i) t)
+                              in (T.take (limit - 1) i, T.drop (T.length i) t)
                          else (T.empty, t)
         result = go (limit - T.length indent) (tokenize modifiedText)
     in (indent <>) <$> result

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -50,3 +50,10 @@ main = hspec $ do
         `shouldBe` [ "  Hello", "  Crazy", "  World", "  !"
                    , "  Reall", "  yLong", "  Token"
                    ]
+
+    it "gracefully handles indentation longer than the target width" $ do
+      let s = defaultWrapSettings { breakLongWords = True
+                                  , preserveIndentation = True
+                                  }
+      wrapTextToLines s 4 "           foo bar"
+        `shouldBe` ["   f", "   o", "   o", "   b", "   a", "   r"]


### PR DESCRIPTION
I noticed while testing the last one that the corner case of having an indentation longer than the target width *and* having both of the settings `True` causes a negative `lim`, which then causes `breakTokens` to diverge.

There are probably other solutions to this problem, but ensuring the indent length is of length at most `limit - 1` seemed like a good start.