### PR TITLE
Remove >= from cabal-version

### DIFF
--- a/word-wrap.cabal
+++ b/word-wrap.cabal
@@ -9,7 +9,7 @@ maintainer:          cygnus@foobox.com
 copyright:           2017 Jonathan Daugherty
 category:            Text
 build-type:          Simple
-cabal-version:       >=1.18
+cabal-version:       1.18
 Homepage:            https://github.com/jtdaugherty/word-wrap/
 Bug-reports:         https://github.com/jtdaugherty/word-wrap/issues
 


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: word-wrap.cabal:12:28: Packages with 'cabal-version: 1.12' or later
should specify a specific version of the Cabal spec of the form
'cabal-version: x.y'. Use 'cabal-version: 1.18'.
```